### PR TITLE
fix: clarification gate, work_finish base-branch guard, triage effort floor (v0.2.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.20 - 2026-04-06
+
+- **Bug fix (clarification):** Added scope-ambiguity detection to the Telegram bootstrap flow. When a request spans 3+ subsystems (auth, notifications, workers, DB...) without explicit tech choices, the bot now asks for clarification before registering the project instead of proceeding with a vague LLM-minimised spec. User can reply "livre"/"your call" to skip and let the bot decide. Closes #1.
+- **Bug fix (work_finish):** `work_finish` now emits a clear, actionable error with exact `git worktree add` and `gh pr create` commands when the developer tries to complete a task while still on the base branch (main/integration/etc.) without any open PR. Replaces the previous misleading `--head main` suggestion. Closes #2.
+- **Bug fix (triage effort):** Effort calculation now applies a complexity floor derived from rawIdea signals. Requests with 4+ subsystem keywords (auth, worker, notifications, realtime...) floor at `effort:large`; 2–3 subsystems floor at `effort:medium`. Prevents complex multi-system features from being classified as `effort:small` when the LLM-generated spec is thin. The auth gate signal detection now also searches rawIdea directly. Closes #3.
+
 ## 0.2.19 - 2026-04-06
 
 - Fixed developer feedback-cycle dispatch so task messages reuse the actual PR branch/worktree instead of always pointing back to the canonical issue branch.

--- a/lib/dispatch/telegram-bootstrap-hook.ts
+++ b/lib/dispatch/telegram-bootstrap-hook.ts
@@ -137,11 +137,65 @@ const BOOTSTRAP_MESSAGES = {
     pt: "Como você quer chamar o projeto? Se preferir, posso escolher um nome.",
     en: "What do you want to name the project? If you prefer, I can pick one.",
   },
+  clarifyScope: {
+    pt: (idea: string) =>
+      `Recebi! Seu pedido envolve vários subsistemas (autenticação, notificações, worker, banco de dados...). Para montar uma spec de qualidade, preciso de algumas definições:\n\n` +
+      `1. **Stack/linguagem**: qual prefere? (Python/FastAPI, Node.js/Express, Go...)\n` +
+      `2. **Banco de dados**: PostgreSQL, MongoDB, Redis, outro?\n` +
+      `3. **Autenticação**: JWT, OAuth2, sessão?\n\n` +
+      `Se preferir deixar a escolha comigo, responda "livre" e eu decido.`,
+    en: (idea: string) =>
+      `Got it! Your request involves multiple subsystems (auth, notifications, background worker, DB...). To produce a quality spec, I need a few decisions:\n\n` +
+      `1. **Stack/language**: which do you prefer? (Python/FastAPI, Node.js/Express, Go...)\n` +
+      `2. **Database**: PostgreSQL, MongoDB, Redis, other?\n` +
+      `3. **Auth**: JWT, OAuth2, session?\n\n` +
+      `If you want me to choose, reply "your call" and I'll decide.`,
+  },
   registered: {
     pt: (name: string, link: string) => `Projeto "${name}" registrado.\nVou continuar o fluxo em ${link}`,
     en: (name: string, link: string) => `Project "${name}" registered.\nI'll continue the flow at ${link}`,
   },
 } as const;
+
+/**
+ * Detect when a request spans multiple subsystems without explicit tech choices.
+ * Returns true when the user should be asked for clarification before registering.
+ *
+ * Criteria:
+ * - 3+ subsystem signals in the rawIdea, AND
+ * - No explicit tech choice for at least one key dimension (DB or auth method), AND
+ * - The user didn't explicitly say "your call" / "livre" (opt-out of clarification)
+ */
+function detectScopeAmbiguity(rawIdea: string, stackHint: string | null | undefined): boolean {
+  const text = rawIdea.toLowerCase();
+
+  // User opted out of clarification
+  if (/\b(livre|free.?choice|your.?call|pode.?escolher|voc[eê].?decide|qualquer)\b/i.test(text)) {
+    return false;
+  }
+
+  // Count subsystem signals
+  const subsystems = [
+    /\b(worker|background.?job|queue|task.?runner|celery|bull)\b/i,
+    /\b(websocket|sse|real.?time|realtime|push.?notif)\b/i,
+    /\b(auth|oauth|jwt|login|register|signup|autenticac)\b/i,
+    /\b(notif|alert|assinatura|subscription|subscribe|email|sms)\b/i,
+    /\b(banco|database|db|postgres|mysql|mongodb|redis|sqlite)\b/i,
+    /\b(api\s+rest|rest\s+api|endpoint|graphql|grpc)\b/i,
+    /\b(dashboard|frontend|interface|ui|tela)\b/i,
+  ];
+  const matchedSubsystems = subsystems.filter(r => r.test(text)).length;
+  if (matchedSubsystems < 3) return false;
+
+  // Check if user gave explicit tech choices for key dimensions
+  const hasExplicitDB = /\b(postgres(ql)?|mysql|mongodb|mongo|redis|sqlite|supabase|dynamodb|cockroach)\b/i.test(text);
+  const hasExplicitAuth = /\b(jwt|oauth2?|basic.?auth|api.?key|session.?based|cookie.?auth)\b/i.test(text);
+  const hasExplicitStack = !!stackHint && !["api", "rest-api", "backend"].includes(stackHint);
+
+  // Ambiguous when at least 2 key dimensions are unspecified
+  const unspecifiedDimensions = [!hasExplicitDB, !hasExplicitAuth, !hasExplicitStack].filter(Boolean).length;
+  return unspecifiedDimensions >= 2;
+}
 
 function inferProjectSlug(text: string): string | undefined {
   let cleaned = text
@@ -782,6 +836,33 @@ async function handleTelegramBootstrapDmMessage(
       language,
     ));
     return;
+  }
+
+  // Scope ambiguity check: even when a stack is (loosely) detected, trigger clarification
+  // when the request spans 3+ subsystems without explicit tech choices.
+  if (detectScopeAmbiguity(content, parsed.stackHint)) {
+    const existingSession = await readTelegramBootstrapSession(workspaceDir, conversationId);
+    // Only ask once — skip if we already asked about scope and the user replied
+    const alreadyAskedScope = existingSession?.pendingClarification === "scope";
+    if (!alreadyAskedScope) {
+      await upsertTelegramBootstrapSession(workspaceDir, {
+        conversationId,
+        rawIdea: content,
+        stackHint: parsed.stackHint ?? undefined,
+        projectName: parsed.projectSlug ?? undefined,
+        status: "clarifying",
+        pendingClarification: "scope",
+        language,
+      });
+      const clarifyMsg = BOOTSTRAP_MESSAGES.clarifyScope[language](content);
+      await sendTelegramText(ctx, rawConversationId, clarifyMsg);
+      return;
+    }
+    // User already answered the scope question — merge their answer as stackHint refinement
+    // and proceed with bootstrap. The answers will flow into conduct-interview via raw_idea context.
+    if (existingSession?.stackHint) {
+      incomingRequest.stackHint = existingSession.stackHint;
+    }
   }
 
   const handled = await runBootstrapPreflightOrFail(

--- a/lib/dispatch/telegram-bootstrap-session.ts
+++ b/lib/dispatch/telegram-bootstrap-session.ts
@@ -68,7 +68,7 @@ export type TelegramBootstrapSession = {
   topicKickoffSentAt?: string | null;
   projectTickedAt?: string | null;
   completionAckSentAt?: string | null;
-  pendingClarification?: "stack" | "stack_and_name" | "name" | null;
+  pendingClarification?: "stack" | "stack_and_name" | "name" | "scope" | null;
   orphanedArtifacts?: PipelineArtifact[] | null;
   createdAt: string;
   updatedAt: string;
@@ -345,7 +345,7 @@ export async function upsertTelegramBootstrapSession(
     repoUrl?: string | null;
     repoPath?: string | null;
     status: TelegramBootstrapStatus;
-    pendingClarification?: "stack" | "stack_and_name" | "name" | null;
+    pendingClarification?: "stack" | "stack_and_name" | "name" | "scope" | null;
     orphanedArtifacts?: PipelineArtifact[] | null;
     error?: string | null;
     projectSlug?: string | null;

--- a/lib/intake/lib/triage-logic.ts
+++ b/lib/intake/lib/triage-logic.ts
@@ -47,12 +47,60 @@ export type TriageDecision = {
   specQualityBlock?: boolean;
 };
 
-/** Calculate effort from files changed and AC count. */
-export function calculateEffort(filesChanged: number, acCount: number): TriageEffort {
-  if (filesChanged <= 3 && acCount <= 3) return "small";
-  if (filesChanged <= 10 && acCount <= 7) return "medium";
-  if (filesChanged <= 25 && acCount <= 15) return "large";
-  return "xlarge";
+/**
+ * Detect signals in rawIdea that indicate a multi-subsystem or complex request.
+ * Used to floor the effort estimate when the LLM-generated spec is too thin.
+ */
+export function detectRawIdeaComplexity(rawIdea: string): { floor: TriageEffort | null; signals: string[] } {
+  const text = rawIdea.toLowerCase();
+  const signals: string[] = [];
+
+  // Multi-subsystem indicators
+  const subsystemPatterns: Array<[RegExp, string]> = [
+    [/\b(worker|background.?job|queue|celery|bull|sidekiq|task.?runner)\b/i, "background-worker"],
+    [/\b(websocket|server.?sent|sse|real.?time|realtime|socket\.io|push.?notif)\b/i, "realtime"],
+    [/\b(auth|oauth|jwt|login|register|session|user.?account|signup)\b/i, "auth"],
+    [/\b(notif|alert|email|sms|webhook|subscription|subscribe)\b/i, "notifications"],
+    [/\b(database|banco|db|postgres|mysql|mongodb|redis|sqlite|orm)\b/i, "database"],
+    [/\b(api\s+rest|rest\s+api|endpoint|rota|route|graphql|grpc)\b/i, "api-layer"],
+    [/\b(docker|kubernetes|k8s|deploy|ci|cd|pipeline)\b/i, "infra"],
+    [/\b(dashboard|frontend|interface|ui|tela|p[aá]gina)\b/i, "frontend"],
+  ];
+
+  for (const [regex, label] of subsystemPatterns) {
+    if (regex.test(text)) signals.push(label);
+  }
+
+  // Floor logic: 3+ subsystems = medium floor, 4+ = large floor
+  let floor: TriageEffort | null = null;
+  if (signals.length >= 4) floor = "large";
+  else if (signals.length >= 3) floor = "medium";
+  else if (signals.length >= 2) floor = "medium";
+
+  return { floor, signals };
+}
+
+/** Calculate effort from files changed and AC count, floored by rawIdea complexity signals. */
+export function calculateEffort(filesChanged: number, acCount: number, rawIdea?: string): TriageEffort {
+  let effort: TriageEffort;
+  if (filesChanged <= 3 && acCount <= 3) effort = "small";
+  else if (filesChanged <= 10 && acCount <= 7) effort = "medium";
+  else if (filesChanged <= 25 && acCount <= 15) effort = "large";
+  else effort = "xlarge";
+
+  // Apply complexity floor from rawIdea signals to prevent under-triage of complex prompts
+  // when the LLM-generated spec is thin.
+  if (rawIdea) {
+    const { floor } = detectRawIdeaComplexity(rawIdea);
+    if (floor) {
+      const ORDER: TriageEffort[] = ["small", "medium", "large", "xlarge"];
+      if (ORDER.indexOf(floor) > ORDER.indexOf(effort)) {
+        effort = floor;
+      }
+    }
+  }
+
+  return effort;
 }
 
 /** Calculate priority using the v2 rules matrix. */
@@ -112,7 +160,8 @@ export function validateDoR(input: TriageInput): string[] {
     }
   }
 
-  // Auth gate
+  // Auth gate: detect auth intent from rawIdea OR objective (not just spec-derived texts).
+  // This prevents the gate from being bypassed when the LLM spec minimises auth details.
   let authSignal = input.authSignal;
   if (!authSignal) {
     const signalText = `${input.rawIdea} ${input.objective}`.toLowerCase();
@@ -120,6 +169,9 @@ export function validateDoR(input: TriageInput): string[] {
   }
 
   if (authSignal) {
+    // Evidence must exist in the GENERATED spec (ACs + scope + objective), not rawIdea.
+    // rawIdea is used only for signal detection — if the LLM spec didn't capture auth,
+    // that IS the problem we want to flag.
     const evidenceText = `${input.acText} ${input.scopeText} ${input.objective}`.toLowerCase();
     if (!AUTH_REGEX.test(evidenceText)) {
       errors.push("dor_auth_requirements_missing");
@@ -143,7 +195,7 @@ export function determineLevel(effort: TriageEffort, targetState: string): strin
 
 /** Run full triage logic. */
 export function runTriageLogic(input: TriageInput, matrix: TriageMatrix): TriageDecision {
-  const effort = calculateEffort(input.filesChanged, input.acCount);
+  const effort = calculateEffort(input.filesChanged, input.acCount, input.rawIdea);
   const { priority, label: priorityLabel } = calculatePriority(input.type, effort, input.totalRisks, matrix);
 
   const effortLabel = matrix.effort_rules[effort]?.label ?? `effort:${effort}`;

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -150,7 +150,27 @@ export async function validatePrExistsForDeveloper(
 
     // Developer completion requires an OPEN PR. Historical merged PRs are not enough,
     // otherwise the reviewer/tester pipeline can be re-entered without a reviewable artifact.
+
     if (!prStatus.url || prStatus.state === PrState.MERGED || prStatus.state === PrState.CLOSED) {
+      // Specific guard: if on base branch with no open PR, give a clear actionable message
+      // instead of the generic "No PR found" error with the misleading --head main suggestion.
+      if (preferIssuePr && isCurrentProjectBaseBranch(branchName, baseBranch)) {
+        const currentBase = branchName || baseBranch || "main";
+        const suggestedBranch = `feature/${issueId}-${projectSlug.replace(/[^a-z0-9]+/g, "-").slice(0, 40)}`;
+        throw new Error(
+          `Cannot mark work_finish(done) while on the base branch ("${currentBase}") without an open PR.\n\n` +
+          `You must implement changes on a feature branch and open a PR before calling work_finish.\n\n` +
+          `Steps to fix:\n` +
+          `  1. git worktree add ../${projectSlug}.worktrees/${suggestedBranch} -b ${suggestedBranch}\n` +
+          `  2. cd ../${projectSlug}.worktrees/${suggestedBranch}\n` +
+          `  3. Implement the changes there, commit, push, and create a PR:\n` +
+          `     git push -u origin ${suggestedBranch}\n` +
+          `     gh pr create --base ${baseBranch ?? "main"} --head ${suggestedBranch} --title "feat: ..." --body "Closes #${issueId}"\n` +
+          `  4. Then call work_finish again.\n\n` +
+          `If the worktree already exists, cd into it and continue from there.`,
+        );
+      }
+
       // Get current branch for a helpful gh pr create example
       const currentBranch = branchName || "current-branch";
 
@@ -164,7 +184,7 @@ export async function validatePrExistsForDeveloper(
         `Cannot mark work_finish(done) without an open PR.\n\n` +
         `${reason}\n\n` +
         `Please create a PR first:\n` +
-        `  gh pr create --base main --head ${currentBranch} --title "..." --body "..."\n\n` +
+        `  gh pr create --base ${baseBranch ?? "main"} --head ${currentBranch} --title "..." --body "Closes #${issueId}"\n\n` +
         `Then call work_finish again.`,
       );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mestreyoda/fabrica",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mestreyoda/fabrica",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mestreyoda/fabrica",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Autonomous software engineering pipeline for OpenClaw. Turns ideas into deployed code via intake, dispatch, review, test, and merge.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Correções (3 bugs identificados em QA 2026-04-06)

### Bug #1 — Pipeline nunca pede clarificação para prompts vagos
Closes #1

Adicionada função `detectScopeAmbiguity()` no `telegram-bootstrap-hook.ts`.
Quando um pedido menciona 3+ subsistemas (auth, notificações, worker, DB...) sem escolhas técnicas explícitas, o bot envia uma mensagem de clarificação antes de registrar o projeto.
O usuário pode responder "livre" ou "your call" para pular e deixar o bot decidir.
Adicionado `"scope"` ao tipo `pendingClarification` na session.

### Bug #2 — work_finish aceita branch base sem PR
Closes #2

`work_finish` agora lança um erro claro com passos exatos (`git worktree add` + `gh pr create`) quando o developer tenta completar na branch base sem PR aberto.
Substitui a mensagem anterior com `--head main` que era inútil e confusa.

### Bug #3 — Triage classifica effort:small incorretamente
Closes #3

`calculateEffort()` aceita `rawIdea` opcional e aplica floor de complexidade via `detectRawIdeaComplexity()`:
- 2+ sinais de subsistema → floor `medium`
- 4+ sinais → floor `large`

Impede que features multi-sistema sejam classificadas como `small` quando o LLM gerou um spec raso.

## Testes
1210 testes passando (176 arquivos).