### PR TITLE
feat: harden Fabrica autonomy, acceptance, and operational timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.24 - 2026-04-07
+
+- Hardened Fabrica intake, triage, and acceptance flow so request fidelity, clarification policy, and runtime quality signals are carried from intake through final completion.
+- Added explicit dispatch semantics and trigger-source auditing, plus clearer worker lifecycle notifications for fresh dispatches, resumes, feedback redispatches, and bootstrap-triggered cycles.
+- Introduced stack policies, quality gates, done policies, and final acceptance summaries so completion decisions and human notifications carry more concrete evidence and archetype-aware reasoning.
+- Propagated triage criticality/risk into issue runtime and parent-family rollups, improving final acceptance, operational timelines, and parent decomposition visibility.
+
 ## 0.2.23 - 2026-04-07
 
 - Completed the parent/child runtime promotion for large work: decomposition metadata is now canonical in issue runtime, child issues carry dependency bindings, recommended level hints, and parent families persist a parallelism ceiling.

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -70,6 +70,8 @@ export type DispatchOpts = {
   instanceName?: string;
   /** Injected runCommand for dependency injection. */
   runCommand: RunCommand;
+  /** Origin of the dispatch cycle for auditability. */
+  triggerSource?: "heartbeat_periodic" | "bootstrap_immediate_tick" | "followup_tick" | "manual_target_role" | "unknown";
 };
 
 export type DispatchResult = {
@@ -105,6 +107,7 @@ export async function dispatchTask(
     issueDescription, issueUrl, role, level, fromLabel, toLabel,
     provider, pluginConfig, runtime,
   } = opts;
+  const triggerSource = opts.triggerSource ?? "unknown";
 
   const slotIndex = opts.slotIndex ?? 0;
   const rc = opts.runCommand;
@@ -168,6 +171,8 @@ export async function dispatchTask(
       role,
       level,
       fromLabel,
+      triggerSource,
+      dispatchSemantic: "feedback_redispatch",
       sessionKey: existingSessionKey,
       reason: "developer_feedback_cycle_requires_fresh_context",
     }).catch(() => {});
@@ -234,6 +239,8 @@ export async function dispatchTask(
         issue: issueId,
         role,
         level,
+        triggerSource,
+        dispatchSemantic: feedbackFreshSession ? "feedback_redispatch" : "fresh_dispatch",
         sessionKey,
         reason: feedbackFreshSession
           ? "gateway_session_alive_without_local_slot_tracking_after_feedback_reset"
@@ -536,6 +543,7 @@ export async function dispatchTask(
       effectiveModel: effectiveModel.downgraded ? model : undefined,
       dispatchCycleId,
       dispatchRunId: sendResult.runId,
+      triggerSource,
     },
     {
       workspaceDir,
@@ -556,13 +564,26 @@ export async function dispatchTask(
 
   // Step 5: Audit
   await auditDispatch(workspaceDir, {
-    project: project.name, issueId, issueTitle,
-    role, level, requestedModel: resolvedModel, resolvedModel, effectiveModel: model,
-    modelDowngraded: effectiveModel.downgraded, modelFallbackReason: effectiveModel.reason,
+    project: project.name,
+    issueId,
+    issueTitle,
+    role,
+    level,
+    requestedModel: resolvedModel,
+    resolvedModel,
+    effectiveModel: model,
+    modelDowngraded: effectiveModel.downgraded,
+    modelFallbackReason: effectiveModel.reason,
     modelAvailability: effectiveModel.availableModels,
     workflowMeta: resolvedConfig.workflowMeta,
-    sessionAction, sessionKey,
-    fromLabel, toLabel, sessionLabel, sessionLabelFull,
+    sessionAction,
+    dispatchSemantic,
+    triggerSource,
+    sessionKey,
+    fromLabel,
+    toLabel,
+    sessionLabel,
+    sessionLabelFull,
   });
 
   const announcement = buildAnnouncement(level, role, sessionAction, issueId, issueTitle, issueUrl, resolvedRole, botName);
@@ -611,6 +632,8 @@ async function auditDispatch(
     modelAvailability: string[];
     workflowMeta: WorkflowResolutionMeta;
     sessionAction: string;
+    dispatchSemantic: string;
+    triggerSource: string;
     sessionKey: string; fromLabel: string; toLabel: string; sessionLabel: string; sessionLabelFull: string;
   },
 ): Promise<void> {
@@ -618,7 +641,10 @@ async function auditDispatch(
     project: opts.project,
     issue: opts.issueId, issueTitle: opts.issueTitle,
     role: opts.role, level: opts.level,
-    sessionAction: opts.sessionAction, sessionKey: opts.sessionKey,
+    sessionAction: opts.sessionAction,
+    dispatchSemantic: opts.dispatchSemantic,
+    sessionKey: opts.sessionKey,
+    triggerSource: opts.triggerSource,
     sessionLabel: opts.sessionLabel,
     sessionLabelFull: opts.sessionLabelFull,
     labelTransition: `${opts.fromLabel} → ${opts.toLabel}`,
@@ -629,6 +655,8 @@ async function auditDispatch(
     role: opts.role,
     level: opts.level,
     sessionAction: opts.sessionAction,
+    dispatchSemantic: opts.dispatchSemantic,
+    triggerSource: opts.triggerSource,
     sessionKey: opts.sessionKey,
     sessionLabel: opts.sessionLabel,
     sessionLabelFull: opts.sessionLabelFull,

--- a/lib/dispatch/notify.ts
+++ b/lib/dispatch/notify.ts
@@ -49,6 +49,7 @@ export type NotifyEvent =
       effectiveModel?: string;
       dispatchCycleId?: string | null;
       dispatchRunId?: string | null;
+      triggerSource?: string | null;
     }
   | {
       type: "workerProgress";
@@ -77,6 +78,7 @@ export type NotifyEvent =
       nextState?: string;
       prUrl?: string;
       createdTasks?: Array<{ id: number; title: string; url: string }>;
+      acceptanceSummary?: string;
       dispatchCycleId?: string | null;
       dispatchRunId?: string | null;
     }
@@ -166,6 +168,7 @@ export type NotifyEvent =
       issueUrl: string;
       issueTitle: string;
       prUrl?: string;
+      acceptanceSummary?: string;
     }
   | {
       type: "holdEscapeResolved";
@@ -302,6 +305,9 @@ export function buildMessage(event: NotifyEvent): string {
       if (event.summary) {
         msg += `\n${event.summary}`;
       }
+      if (event.acceptanceSummary) {
+        msg += `\n🧾 ${event.acceptanceSummary}`;
+      }
       // Links: PR and issue on separate lines
       if (event.prUrl) msg += `\n🔗 ${prLink(event.prUrl)}`;
       msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
@@ -396,6 +402,7 @@ export function buildMessage(event: NotifyEvent): string {
     case "issueComplete": {
       let msg = `🏁 Issue completed: #${event.issueId} — ${event.issueTitle}`;
       msg += `\n📦 Project: ${event.project}`;
+      if (event.acceptanceSummary) msg += `\n🧾 ${event.acceptanceSummary}`;
       if (event.prUrl) msg += `\n🔗 ${prLink(event.prUrl)}`;
       msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
       msg += `\n✅ Issue closed — work delivered.`;

--- a/lib/dispatch/telegram-bootstrap-hook.ts
+++ b/lib/dispatch/telegram-bootstrap-hook.ts
@@ -1604,6 +1604,7 @@ async function completeRegisteredBootstrap(
         runtime: ctx.runtime,
         runCommand: ctx.runCommand,
         maxPickups: 1,
+        triggerSource: "bootstrap_immediate_tick",
       });
     } catch (error) {
       logBootstrapWarning(ctx, `[telegram-bootstrap] immediate projectTick failed: ${error instanceof Error ? error.message : String(error)}`);

--- a/lib/intake/steps/triage.ts
+++ b/lib/intake/steps/triage.ts
@@ -140,6 +140,8 @@ export const triageStep: PipelineStep = {
                 childReadyForDispatch: decision.targetState === "To Do",
                 parallelizable: child.draft.parallelizable,
                 recommendedLevel: child.draft.recommendedLevel,
+                qualityCriticality: decision.qualityCriticality,
+                riskProfile: decision.riskProfile,
                 decompositionMode: "none",
                 decompositionStatus: null,
               }).catch(() => {});
@@ -147,6 +149,8 @@ export const triageStep: PipelineStep = {
             await updateIssueRuntime(ctx.workspaceDir, projectSlug, issue.number, {
               childIssueIds: createdChildIssueNumbers,
               maxParallelChildren: computeMaxParallelChildren(decompositionDrafts),
+              qualityCriticality: decision.qualityCriticality,
+              riskProfile: decision.riskProfile,
               decompositionMode: "parent_child",
               decompositionStatus: "active",
             }).catch(() => {});
@@ -262,6 +266,14 @@ export const triageStep: PipelineStep = {
         messageThreadId: payload.metadata?.message_thread_id ?? null,
         triageReadyForDispatch: triage.ready_for_dispatch,
         triageErrors: triage.errors,
+      }).catch(() => {});
+    }
+
+    const resolvedProjectSlug = payload.metadata?.project_slug ?? payload.scaffold?.project_slug ?? null;
+    if (resolvedProjectSlug) {
+      await updateIssueRuntime(ctx.workspaceDir, resolvedProjectSlug, issue.number, {
+        qualityCriticality: decision.qualityCriticality,
+        riskProfile: decision.riskProfile,
       }).catch(() => {});
     }
 

--- a/lib/projects/mutations.ts
+++ b/lib/projects/mutations.ts
@@ -352,6 +352,8 @@ export async function clearIssueRuntime(
         decompositionStatus: existing.parentIssueId ? "completed" : (existing.decompositionStatus ?? null),
         sessionCompletedAt: existing.sessionCompletedAt ?? new Date().toISOString(),
         artifactOfRecord: existing.artifactOfRecord ?? null,
+        qualityCriticality: existing.qualityCriticality ?? null,
+        riskProfile: existing.riskProfile ?? null,
       } : null;
       if (preserved && (
         preserved.parentIssueId != null ||

--- a/lib/projects/types.ts
+++ b/lib/projects/types.ts
@@ -86,6 +86,8 @@ export type IssueRuntimeState = {
   lastDispatchedLevel?: string | null;
   lastFailureReason?: "stall" | "infra" | "complexity" | null;
   lastDiagnosticResult?: string | null;
+  qualityCriticality?: "low" | "medium" | "high" | null;
+  riskProfile?: string[] | null;
 };
 
 export type ProjectEnvironmentStatus = "pending" | "provisioning" | "ready" | "failed";

--- a/lib/services/heartbeat/tick-runner.ts
+++ b/lib/services/heartbeat/tick-runner.ts
@@ -231,6 +231,7 @@ export async function tick(opts: {
         instanceName,
         runtime,
         runCommand,
+        triggerSource: "heartbeat_periodic",
       });
 
       result.totalPickups += tickResult.pickups.length;

--- a/lib/services/parent-lifecycle.ts
+++ b/lib/services/parent-lifecycle.ts
@@ -44,10 +44,14 @@ function formatChildRollupLine(child: { issueId: number; runtime: IssueRuntimeSt
   const prUrl = runtime?.artifactOfRecord?.url ?? runtime?.currentPrUrl ?? null;
   const mergedAt = runtime?.artifactOfRecord?.mergedAt ?? null;
   const headSha = runtime?.artifactOfRecord?.headSha ?? runtime?.lastHeadSha ?? null;
+  const qualityCriticality = runtime?.qualityCriticality ?? null;
+  const riskProfile = runtime?.riskProfile ?? [];
   const extras = [
     prUrl ? `PR: ${prUrl}` : null,
     mergedAt ? `mergedAt: ${mergedAt}` : null,
     headSha ? `headSha: ${headSha}` : null,
+    qualityCriticality ? `qualityCriticality: ${qualityCriticality}` : null,
+    riskProfile.length > 0 ? `risks: ${riskProfile.join(",")}` : null,
   ].filter(Boolean);
   return `- #${child.issueId} — ${state}${extras.length > 0 ? ` — ${extras.join(" — ")}` : ""}`;
 }
@@ -58,12 +62,14 @@ const PARENT_ROLLUP_END = "<!-- fabrica:parent-rollup:end -->";
 function buildParentRollupComment(status: NonNullable<IssueRuntimeState["decompositionStatus"]>, completedChildIds: number[], blockedChildIds: number[], children: Array<{ issueId: number; runtime: IssueRuntimeState | undefined }>): string {
   const allChildIds = children.map((child) => child.issueId);
   const pendingChildIds = allChildIds.filter((id) => !completedChildIds.includes(id) && !blockedChildIds.includes(id));
+  const highCriticalityChildren = children.filter((child) => child.runtime?.qualityCriticality === "high").map((child) => child.issueId);
   return [
     "## Parent Rollup",
     `- Status: ${status}`,
     `- Completed children (${completedChildIds.length}/${allChildIds.length}): ${completedChildIds.length > 0 ? completedChildIds.map((id) => `#${id}`).join(", ") : "none"}`,
     `- Pending children: ${pendingChildIds.length > 0 ? pendingChildIds.map((id) => `#${id}`).join(", ") : "none"}`,
     `- Blocked children: ${blockedChildIds.length > 0 ? blockedChildIds.map((id) => `#${id}`).join(", ") : "none"}`,
+    `- High-criticality children: ${highCriticalityChildren.length > 0 ? highCriticalityChildren.map((id) => `#${id}`).join(", ") : "none"}`,
     "",
     "### Child Status",
     ...children.map((child) => formatChildRollupLine(child)),

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -1465,6 +1465,7 @@ describe("E2E pipeline", () => {
         role: "tester",
         result: "pass",
         issueId: 90,
+        summary: "Tester verified the main flow and exit conditions successfully.",
         provider: h.provider,
         repoPath: "/tmp/test-repo",
         projectName: "test-project",

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -6,11 +6,13 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import { PrState, type StateLabel, type IssueProvider, type PrStatus } from "../providers/provider.js";
 import { deactivateWorker, loadProjectBySlug, getRoleWorker, getIssueRuntime, clearIssueRuntime, updateIssueRuntime } from "../projects/index.js";
+import type { Channel, Project } from "../projects/index.js";
 import type { PrSelector } from "../providers/provider.js";
 import type { RunCommand } from "../context.js";
 import { notify, getNotificationConfig } from "../dispatch/notify.js";
 import { log as auditLog } from "../audit.js";
 import { loadConfig } from "../config/index.js";
+import type { DeliveryTarget } from "../intake/types.js";
 import { detectStepRouting } from "./queue-scan.js";
 import { reconcileParentLifecycleForIssue } from "./parent-lifecycle.js";
 import {
@@ -25,9 +27,10 @@ import {
   type CompletionRule,
   type WorkflowConfig,
 } from "../workflow/index.js";
-import type { Channel } from "../projects/index.js";
 import { withCorrelationContext } from "../observability/context.js";
 import { withTelemetrySpan } from "../observability/telemetry.js";
+import { resolveQualityGatePolicy } from "../quality/quality-gates.js";
+import { resolveDonePolicy } from "../quality/done-policies.js";
 
 export type { CompletionRule };
 
@@ -39,6 +42,16 @@ export type CompletionOutput = {
   issueUrl?: string;
   issueClosed?: boolean;
   issueReopened?: boolean;
+  finalAcceptance?: FinalAcceptanceSummary;
+};
+
+export type FinalAcceptanceSummary = {
+  deliverable: string;
+  fidelityStatus: "pass" | "warn";
+  qualityGateStatus: "pass" | "warn";
+  evidenceStatus: "pass" | "fail";
+  donePolicyStatus: "pass" | "warn";
+  openConcerns: string[];
 };
 
 export type CloseGuardIssueRuntime = {
@@ -61,6 +74,83 @@ export type CloseGuardEvaluation = {
   reason?: "open_pr" | "missing_artifact_of_record" | "follow_up_pr_required";
   currentPrNumber?: number | null;
 };
+
+function hasMeaningfulCompletionEvidence(summary?: string, prUrl?: string, createdTasks?: Array<{ id: number; title: string; url: string }>): boolean {
+  if (summary && summary.trim().length >= 12) return true;
+  if (prUrl && prUrl.trim().length > 0) return true;
+  if (createdTasks && createdTasks.length > 0) return true;
+  return false;
+}
+
+function hasArchetypeSpecificEvidence(deliverable: DeliveryTarget, summary?: string, prUrl?: string, createdTasks?: Array<{ id: number; title: string; url: string }>): boolean {
+  if (prUrl && prUrl.trim().length > 0) return true;
+  if (createdTasks && createdTasks.length > 0) return true;
+  const text = (summary ?? "").toLowerCase();
+  if (!text) return deliverable === "unknown";
+  if (deliverable === "cli") return /cli|command|help|exit|argv|flag|terminal/.test(text);
+  if (deliverable === "api") return /api|endpoint|route|request|response|validation|handler/.test(text);
+  if (deliverable === "web-ui") return /ui|screen|page|render|flow|loading|error|form/.test(text);
+  if (deliverable === "hybrid") return /api|ui|flow|integration|endpoint|screen/.test(text);
+  return true;
+}
+
+function buildFinalAcceptanceSummary(opts: {
+  deliverable: string;
+  qualityPolicy: { requiredChecks: string[]; requiredEvidence: string[] };
+  donePolicy: { requiredArtifacts: string[]; requiredEvidence: string[] };
+  hasEvidence: boolean;
+  closeRequested: boolean;
+  qualityCriticality: "low" | "medium" | "high";
+  riskProfile: string[];
+}): FinalAcceptanceSummary {
+  const openConcerns: string[] = [];
+  if (!opts.hasEvidence) openConcerns.push("missing_meaningful_completion_evidence");
+  if (opts.deliverable === "unknown") openConcerns.push("deliverable_inference_is_unknown");
+  if (!opts.closeRequested) openConcerns.push("completion_did_not_request_close");
+  if (opts.qualityCriticality === "high") openConcerns.push("quality_criticality_high_requires_conservative_review");
+  if (opts.riskProfile.length > 0) openConcerns.push(...opts.riskProfile.map((risk) => `risk:${risk}`));
+
+  return {
+    deliverable: opts.deliverable,
+    fidelityStatus: opts.deliverable === "unknown" ? "warn" : "pass",
+    qualityGateStatus: opts.qualityPolicy.requiredChecks.length > 0 ? "pass" : "warn",
+    evidenceStatus: opts.hasEvidence ? "pass" : "fail",
+    donePolicyStatus: opts.donePolicy.requiredArtifacts.length > 0 ? "pass" : "warn",
+    openConcerns,
+  };
+}
+
+function resolvePipelineDeliverable(project?: Project | null): DeliveryTarget {
+  const stack = project?.environment?.stack ?? project?.stack ?? null;
+  if (stack === "nextjs") return "web-ui";
+  if (stack === "node-cli" || stack === "python-cli") return "cli";
+  if (stack === "express" || stack === "fastapi" || stack === "flask" || stack === "django") return "api";
+
+  const nameText = `${project?.name ?? ""} ${project?.slug ?? ""} ${project?.repo ?? ""}`.toLowerCase();
+  if (/\bcli\b|command/.test(nameText)) return "cli";
+  if (/\bapi\b|service|backend/.test(nameText)) return "api";
+  if (/dashboard|frontend|web|ui/.test(nameText)) return "web-ui";
+  return "unknown";
+}
+
+function buildHumanAcceptanceSummary(summary: FinalAcceptanceSummary): string {
+  const badges: string[] = [];
+  badges.push(`deliverable=${summary.deliverable}`);
+  badges.push(`evidence=${summary.evidenceStatus}`);
+  if (summary.fidelityStatus !== "pass") badges.push(`fidelity=${summary.fidelityStatus}`);
+  if (summary.qualityGateStatus !== "pass") badges.push(`quality=${summary.qualityGateStatus}`);
+  if (summary.donePolicyStatus !== "pass") badges.push(`done=${summary.donePolicyStatus}`);
+
+  const concerns = summary.openConcerns.filter((c) =>
+    c === "quality_criticality_high_requires_conservative_review" ||
+    c.startsWith("risk:") ||
+    c === "deliverable_inference_is_unknown",
+  );
+  if (concerns.length > 0) {
+    badges.push(`concerns=${concerns.slice(0, 3).join(",")}`);
+  }
+  return badges.join(" | ");
+}
 
 export async function persistMergedArtifact(opts: {
   workspaceDir: string;
@@ -209,9 +299,79 @@ export async function executeCompletion(opts: {
   let mergedArtifactHeadSha: string | undefined;
   const project = await loadProjectBySlug(workspaceDir, projectSlug);
   const issueRuntime = project ? getIssueRuntime(project, issueId) : undefined;
+  const deliverable = resolvePipelineDeliverable(project);
+  const qualityCriticality = issueRuntime?.qualityCriticality ?? "medium";
+  const qualityPolicy = resolveQualityGatePolicy({ deliverable, qualityCriticality });
+  const donePolicy = resolveDonePolicy({ deliverable, qualityCriticality: qualityPolicy.qualityCriticalityFloor });
   const prSelector: PrSelector | undefined = issueRuntime?.currentPrNumber
     ? { prNumber: issueRuntime.currentPrNumber }
     : undefined;
+
+  const closeRequested = completionRule.actions.includes(Action.CLOSE_ISSUE);
+  const hasEvidence = hasMeaningfulCompletionEvidence(effectiveSummary, prUrl, createdTasks);
+  const hasArchetypeEvidence = hasArchetypeSpecificEvidence(deliverable, effectiveSummary, prUrl, createdTasks);
+  const finalAcceptance = buildFinalAcceptanceSummary({
+    deliverable,
+    qualityPolicy,
+    donePolicy,
+    hasEvidence,
+    closeRequested,
+    qualityCriticality,
+    riskProfile: issueRuntime?.riskProfile ?? [],
+  });
+
+  await auditLog(workspaceDir, "completion_policy_snapshot", {
+    project: projectName,
+    issue: issueId,
+    role,
+    deliverable,
+    qualityGateChecks: qualityPolicy.requiredChecks,
+    requiredEvidence: qualityPolicy.requiredEvidence,
+    doneArtifacts: donePolicy.requiredArtifacts,
+    doneEvidence: donePolicy.requiredEvidence,
+    qualityCriticality,
+    qualityCriticalityFloor: qualityPolicy.qualityCriticalityFloor,
+    riskProfile: issueRuntime?.riskProfile ?? [],
+    finalAcceptance,
+  }).catch(() => {});
+
+  await auditLog(workspaceDir, "final_acceptance_summary", {
+    project: projectName,
+    issue: issueId,
+    role,
+    ...finalAcceptance,
+  }).catch(() => {});
+
+  if (closeRequested && !hasEvidence) {
+    await auditLog(workspaceDir, "completion_policy_block", {
+      project: projectName,
+      issue: issueId,
+      role,
+      result,
+      reason: "missing_completion_evidence",
+      deliverable,
+      requiredEvidence: donePolicy.requiredEvidence,
+    }).catch(() => {});
+    throw new Error(
+      `Refusing to complete issue #${issueId} without meaningful completion evidence for ${deliverable}. ` +
+      `Provide a substantive summary, PR evidence, or created-task evidence before close.`,
+    );
+  }
+
+  if (closeRequested && !hasArchetypeEvidence) {
+    await auditLog(workspaceDir, "completion_policy_block", {
+      project: projectName,
+      issue: issueId,
+      role,
+      result,
+      reason: "missing_archetype_specific_evidence",
+      deliverable,
+    }).catch(() => {});
+    throw new Error(
+      `Refusing to complete issue #${issueId} because the final summary lacks ${deliverable}-specific evidence. ` +
+      `Describe the relevant ${deliverable} behavior more concretely or attach PR/task evidence.`,
+    );
+  }
 
   const shouldBlockMergeBeforeTest = (
     completionRule.actions.includes(Action.MERGE_PR) &&
@@ -379,6 +539,8 @@ export async function executeCompletion(opts: {
   
   await provider.transitionLabel(issueId, completionRule.from as StateLabel, completionRule.to as StateLabel);
 
+  const acceptanceSummary = buildHumanAcceptanceSummary(finalAcceptance);
+
   // Execute post-transition actions
   for (const action of completionRule.actions) {
     switch (action) {
@@ -403,6 +565,7 @@ export async function executeCompletion(opts: {
             issueUrl: issue.web_url,
             issueTitle: issue.title,
             prUrl,
+            acceptanceSummary,
           },
           {
             workspaceDir,
@@ -474,6 +637,7 @@ export async function executeCompletion(opts: {
       name: workerName,
       result: effectiveResult as "done" | "pass" | "fail" | "refine" | "blocked",
       summary: effectiveSummary,
+      acceptanceSummary,
       nextState,
       prUrl,
       createdTasks,
@@ -591,6 +755,7 @@ export async function executeCompletion(opts: {
     issueUrl: issue.web_url,
     issueClosed: completionRule.actions.includes(Action.CLOSE_ISSUE),
     issueReopened: completionRule.actions.includes(Action.REOPEN_ISSUE),
+    finalAcceptance,
   };
 }
 

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -42,6 +42,7 @@ export type TickAction = {
   role: Role;
   level: string;
   sessionAction: "spawn" | "send";
+  triggerSource?: "heartbeat_periodic" | "bootstrap_immediate_tick" | "followup_tick" | "manual_target_role" | "unknown";
   announcement: string;
 };
 
@@ -94,11 +95,14 @@ export async function projectTick(opts: {
   ensureEnvironmentReady?: typeof import("../test-env/runtime.js").ensureEnvironmentReady;
   /** Injected dispatch function for tests. */
   dispatchTask?: typeof import("../dispatch/index.js").dispatchTask;
+  /** Origin of the current tick for auditability. */
+  triggerSource?: "heartbeat_periodic" | "bootstrap_immediate_tick" | "followup_tick" | "manual_target_role" | "unknown";
 }): Promise<TickResult> {
   const {
     workspaceDir, projectSlug, agentId, sessionKey, pluginConfig, dryRun,
     maxPickups, targetRole, runtime, instanceName, runCommand,
   } = opts;
+  const triggerSource = opts.triggerSource ?? (targetRole ? "followup_tick" : "heartbeat_periodic");
   const ensureEnvironment = opts.ensureEnvironmentReady ?? defaultEnsureEnvironmentReady;
   const dispatch = opts.dispatchTask ?? dispatchTask;
 
@@ -399,10 +403,11 @@ export async function projectTick(opts: {
           slotIndex: freeSlot,
           instanceName,
           runCommand: runCommand!,
+          triggerSource,
         });
         pickups.push({
           project: project.name, projectSlug, issueId: issue.iid, issueTitle: issue.title, issueUrl: issue.web_url,
-          role, level: dr.level, sessionAction: dr.sessionAction, announcement: dr.announcement,
+          role, level: dr.level, sessionAction: dr.sessionAction, triggerSource, announcement: dr.announcement,
         });
         // F1-3: Record dispatch for dedup
         await recordDispatch(workspaceDir, dispatchId).catch(() => {}); // best-effort

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mestreyoda/fabrica",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Autonomous software engineering pipeline for OpenClaw. Turns ideas into deployed code via intake, dispatch, review, test, and merge.",
   "type": "module",
   "main": "./dist/index.js",

--- a/tests/e2e/orchestration-smoke.e2e.test.ts
+++ b/tests/e2e/orchestration-smoke.e2e.test.ts
@@ -215,5 +215,12 @@ describe.sequential("orchestration smoke", () => {
       .filter(Boolean)
       .map((line) => JSON.parse(line) as Record<string, unknown>);
     expect(auditLines.some((entry) => entry.event === "reviewer_session_transition")).toBe(true);
+
+    const dispatchAuditEntries = auditLines.filter(
+      (entry) => entry.event === "session_dispatch_requested" && entry.issue === issueId,
+    );
+    expect(dispatchAuditEntries.length).toBeGreaterThanOrEqual(3);
+    expect(dispatchAuditEntries.some((entry) => entry.triggerSource === "unknown")).toBe(true);
+    expect(dispatchAuditEntries.some((entry) => entry.triggerSource === "followup_tick")).toBe(true);
   }, 60_000);
 });

--- a/tests/integration/dispatch-flow.test.ts
+++ b/tests/integration/dispatch-flow.test.ts
@@ -320,6 +320,7 @@ describe("dispatchTask — happy path", () => {
     expect(mockAuditLog).toHaveBeenCalledWith("/tmp/workspace", "session_orphan_reset", expect.objectContaining({
       sessionKey: "agent:unknown:subagent:my-project-developer-junior-alice",
       reason: "gateway_session_alive_without_local_slot_tracking",
+      dispatchSemantic: "fresh_dispatch",
     }));
   });
 
@@ -369,6 +370,11 @@ describe("dispatchTask — happy path", () => {
     const patchParams = JSON.parse(patchCall[0][5]);
     expect(patchParams.key).toMatch(/^agent:unknown:subagent:my-project-developer-junior-alice-retry-/);
     expect(patchParams.key).not.toBe("agent:unknown:subagent:my-project-developer-junior-alice");
+    expect(mockAuditLog).toHaveBeenCalledWith("/tmp/workspace", "session_feedback_reset", expect.objectContaining({
+      triggerSource: "unknown",
+      dispatchSemantic: "feedback_redispatch",
+      reason: "developer_feedback_cycle_requires_fresh_context",
+    }));
   });
 });
 

--- a/tests/unit/close-open-pr.test.ts
+++ b/tests/unit/close-open-pr.test.ts
@@ -5,6 +5,113 @@ import { writeProjects } from "../../lib/projects/index.js";
 import { DEFAULT_WORKFLOW, type WorkflowConfig } from "../../lib/workflow/index.js";
 
 describe("closeIssue invariant", () => {
+  it("refuses to close when there is no meaningful completion evidence", async () => {
+    const unsafeWorkflow = {
+      ...DEFAULT_WORKFLOW,
+      states: {
+        ...DEFAULT_WORKFLOW.states,
+        testing: {
+          ...DEFAULT_WORKFLOW.states.testing,
+          on: {
+            ...DEFAULT_WORKFLOW.states.testing.on,
+            PASS: {
+              target: "done",
+              actions: ["closeIssue"],
+            },
+          },
+        },
+      },
+    } satisfies WorkflowConfig;
+
+    const h = await createTestHarness({
+      workflow: unsafeWorkflow,
+      workers: {
+        tester: { active: true, issueId: "30", level: "medior" },
+      },
+    });
+
+    try {
+      h.provider.seedIssue({ iid: 30, title: "Evidence required", labels: ["Testing"] });
+
+      await expect(executeCompletion({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        channels: h.project.channels,
+        role: "tester",
+        result: "pass",
+        issueId: 30,
+        summary: "ok",
+        provider: h.provider,
+        repoPath: h.project.repo,
+        projectName: h.project.name,
+        workflow: unsafeWorkflow,
+        runCommand: h.runCommand,
+      })).rejects.toThrow(/meaningful completion evidence/);
+
+      const issue = await h.provider.getIssue(30);
+      expect(issue.state).toBe("opened");
+      expect(issue.labels).toContain("Testing");
+      expect(h.provider.callsTo("closeIssue")).toHaveLength(0);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("refuses to close a CLI issue when the summary lacks CLI-specific evidence", async () => {
+    const unsafeWorkflow = {
+      ...DEFAULT_WORKFLOW,
+      states: {
+        ...DEFAULT_WORKFLOW.states,
+        testing: {
+          ...DEFAULT_WORKFLOW.states.testing,
+          on: {
+            ...DEFAULT_WORKFLOW.states.testing.on,
+            PASS: {
+              target: "done",
+              actions: ["closeIssue"],
+            },
+          },
+        },
+      },
+    } satisfies WorkflowConfig;
+
+    const h = await createTestHarness({
+      workflow: unsafeWorkflow,
+      workers: {
+        tester: { active: true, issueId: "30", level: "medior" },
+      },
+    });
+
+    try {
+      h.provider.seedIssue({ iid: 30, title: "CLI evidence required", labels: ["Testing"] });
+      const data = await h.readProjects();
+      data.projects[h.project.slug]!.stack = "python-cli";
+      await writeProjects(h.workspaceDir, data);
+
+      await expect(executeCompletion({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        channels: h.project.channels,
+        role: "tester",
+        result: "pass",
+        issueId: 30,
+        summary: "Everything looks correct and complete now.",
+        provider: h.provider,
+        repoPath: h.project.repo,
+        projectName: h.project.name,
+        workflow: unsafeWorkflow,
+        runCommand: h.runCommand,
+      })).rejects.toThrow(/specific evidence/i);
+
+      const issue = await h.provider.getIssue(30);
+      expect(issue.state).toBe("opened");
+      expect(issue.labels).toContain("Testing");
+      expect(h.provider.callsTo("closeIssue")).toHaveLength(0);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
   it("refuses to close an implementation issue while the canonical PR is still open", async () => {
     const unsafeWorkflow = {
       ...DEFAULT_WORKFLOW,

--- a/tests/unit/dispatch-atomicity.test.ts
+++ b/tests/unit/dispatch-atomicity.test.ts
@@ -271,7 +271,7 @@ describe("dispatch atomicity (C2 fix)", () => {
     expect(runtimeIdx).toBeLessThan(labelIdx);
   });
 
-  it("emits workerStart notifications with dispatch cycle identity", async () => {
+  it("emits workerStart notifications with dispatch cycle identity and trigger source", async () => {
     const { dispatchTask } = await import("../../lib/dispatch/index.js");
 
     await dispatchTask({
@@ -294,12 +294,14 @@ describe("dispatch atomicity (C2 fix)", () => {
       toLabel: "Doing",
       provider: makeProvider(),
       runCommand: makeRunCommand(),
+      triggerSource: "heartbeat_periodic",
     });
 
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "workerStart",
         dispatchCycleId: expect.any(String),
+        triggerSource: "heartbeat_periodic",
       }),
       expect.anything(),
     );

--- a/tests/unit/notify.test.ts
+++ b/tests/unit/notify.test.ts
@@ -267,10 +267,30 @@ describe("notify", () => {
       name: "Ada",
       sessionAction: "spawn",
       dispatchSemantic: "feedback_redispatch",
+      triggerSource: "followup_tick",
     } as any);
 
     expect(message).toContain("Re-dispatched after feedback");
     expect(message).toContain("DEVELOPER Ada (senior)");
+  });
+
+  it("formats workerStart with explicit session resume semantics", () => {
+    const message = buildMessage({
+      type: "workerStart",
+      project: "demo",
+      issueId: 45,
+      issueUrl: "https://example.com/issues/45",
+      issueTitle: "Resume work",
+      role: "reviewer",
+      level: "medior",
+      name: "Riley",
+      sessionAction: "send",
+      dispatchSemantic: "session_resume",
+      triggerSource: "followup_tick",
+    } as any);
+
+    expect(message).toContain("Resumed");
+    expect(message).toContain("REVIEWER Riley (medior)");
   });
 
   it("formats workerRecoveryExhausted as an explicit operational failure timeline event", () => {
@@ -403,6 +423,40 @@ describe("notify", () => {
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }
+  });
+
+  it("formats workerComplete with a short human acceptance summary", () => {
+    const message = buildMessage({
+      type: "workerComplete",
+      project: "demo",
+      issueId: 8,
+      issueUrl: "https://example.com/issues/8",
+      role: "developer",
+      level: "medior",
+      name: "Brittne",
+      result: "done",
+      summary: "Developer completed the CLI behavior and verified the expected flow.",
+      acceptanceSummary: "deliverable=cli | evidence=pass | concerns=risk:auth",
+      nextState: "To Review",
+    } as any);
+
+    expect(message).toContain("🧾 deliverable=cli | evidence=pass | concerns=risk:auth");
+    expect(message).toContain("→ To Review");
+  });
+
+  it("formats issueComplete with a short human acceptance summary", () => {
+    const message = buildMessage({
+      type: "issueComplete",
+      project: "demo",
+      issueId: 99,
+      issueUrl: "https://example.com/issues/99",
+      issueTitle: "Ship CLI",
+      prUrl: "https://example.com/pull/99",
+      acceptanceSummary: "deliverable=cli | evidence=pass",
+    } as any);
+
+    expect(message).toContain("🧾 deliverable=cli | evidence=pass");
+    expect(message).toContain("Issue closed — work delivered");
   });
 
   it("formats a reviewRejected notification with a short rationale", () => {

--- a/tests/unit/parent-lifecycle.test.ts
+++ b/tests/unit/parent-lifecycle.test.ts
@@ -54,6 +54,8 @@ describe("parent lifecycle reconciliation", () => {
           sessionCompletedAt: "2026-04-06T10:00:00Z",
           currentPrUrl: "https://example.com/pr/910",
           currentPrState: "open",
+          qualityCriticality: "high",
+          riskProfile: ["auth"],
         },
         "92": {
           parentIssueId: 90,
@@ -65,6 +67,8 @@ describe("parent lifecycle reconciliation", () => {
           currentPrUrl: "https://example.com/pr/920",
           currentPrIssueTarget: 92,
           lastHeadSha: "facefeed",
+          qualityCriticality: "medium",
+          riskProfile: ["data_model"],
           artifactOfRecord: {
             prNumber: 920,
             headSha: "facefeed",
@@ -94,8 +98,12 @@ describe("parent lifecycle reconciliation", () => {
       const parentIssue = await h.provider.getIssue(90);
       expect(parentIssue.labels).toContain("Done");
       expect(parentIssue.description).toContain("<!-- fabrica:parent-rollup:start -->");
+      expect(parentIssue.description).toContain("High-criticality children: #91");
       expect(parentIssue.description).toContain("#91 — completed_via_session — PR: https://example.com/pr/910");
+      expect(parentIssue.description).toContain("qualityCriticality: high");
+      expect(parentIssue.description).toContain("risks: auth");
       expect(parentIssue.description).toContain("#92 — completed_via_artifact — PR: https://example.com/pr/920");
+      expect(parentIssue.description).toContain("risks: data_model");
       expect(parentIssue.description).toContain("mergedAt: 2026-04-06T10:10:00Z");
       expect(parentIssue.description).toContain("headSha: facefeed");
 

--- a/tests/unit/pipeline-notify.test.ts
+++ b/tests/unit/pipeline-notify.test.ts
@@ -125,8 +125,14 @@ describe("executeCompletion notifications", () => {
 
     mockLoadProjectBySlug.mockResolvedValue({
       slug: "demo",
-      name: "todo-summary",
+      name: "todo-summary-cli",
       repo: "org/repo",
+      stack: "python-cli",
+      environment: {
+        status: "ready",
+        stack: "python-cli",
+        contractVersion: "test-v1",
+      },
       channels: [{ channel: "telegram", channelId: "ops-room", events: ["*"] }],
       workers: {
         developer: {
@@ -139,16 +145,19 @@ describe("executeCompletion notifications", () => {
         "7": {
           lastDispatchCycleId: "cycle-a",
           dispatchRunId: "run-a",
+          qualityCriticality: "high",
+          riskProfile: ["auth", "data_model"],
         },
       },
     });
 
-    await executeCompletion({
+    const result = await executeCompletion({
       workspaceDir: "/tmp/ws",
       projectSlug: "demo",
       role: "developer",
       result: "done",
       issueId: 7,
+      summary: "Developer completed the CLI behavior and verified the expected flow.",
       provider: provider as never,
       repoPath: "/tmp/org-repo",
       projectName: "todo-summary",
@@ -158,14 +167,55 @@ describe("executeCompletion notifications", () => {
       slotIndex: 0,
     });
 
+    expect(result.finalAcceptance).toEqual(expect.objectContaining({
+      deliverable: "cli",
+      fidelityStatus: "pass",
+      evidenceStatus: "pass",
+      qualityGateStatus: "pass",
+      openConcerns: expect.arrayContaining([
+        "quality_criticality_high_requires_conservative_review",
+        "risk:auth",
+        "risk:data_model",
+      ]),
+    }));
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "workerComplete",
         dispatchCycleId: "cycle-a",
         dispatchRunId: "run-a",
+        acceptanceSummary: expect.stringContaining("deliverable=cli"),
       }),
       expect.objectContaining({
         runCommand,
+      }),
+    );
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      "/tmp/ws",
+      "completion_policy_snapshot",
+      expect.objectContaining({
+        issue: 7,
+        role: "developer",
+        deliverable: "cli",
+        qualityCriticality: "high",
+        riskProfile: ["auth", "data_model"],
+        qualityGateChecks: expect.any(Array),
+        doneArtifacts: expect.any(Array),
+        finalAcceptance: expect.objectContaining({
+          evidenceStatus: "pass",
+          openConcerns: expect.arrayContaining([
+            "quality_criticality_high_requires_conservative_review",
+            "risk:auth",
+          ]),
+        }),
+      }),
+    );
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      "/tmp/ws",
+      "final_acceptance_summary",
+      expect.objectContaining({
+        issue: 7,
+        role: "developer",
+        evidenceStatus: "pass",
       }),
     );
   });

--- a/tests/unit/triage-step.test.ts
+++ b/tests/unit/triage-step.test.ts
@@ -223,10 +223,13 @@ describe("triageStep", () => {
     const parentRuntime = persisted.projects.demo?.issueRuntime?.["42"];
     expect(parentRuntime?.decompositionMode).toBe("parent_child");
     expect(parentRuntime?.decompositionStatus).toBe("active");
+    expect(parentRuntime?.qualityCriticality).toBe("high");
+    expect(parentRuntime?.riskProfile).toEqual(expect.arrayContaining(["auth", "async_processing"]));
     expect(parentRuntime?.childIssueIds?.length).toBeGreaterThanOrEqual(2);
     const childIds = parentRuntime?.childIssueIds ?? [];
     for (const childId of childIds) {
       expect(persisted.projects.demo?.issueRuntime?.[String(childId)]?.parentIssueId).toBe(42);
+      expect(persisted.projects.demo?.issueRuntime?.[String(childId)]?.qualityCriticality).toBe("high");
     }
     if (childIds.length >= 2) {
       const secondChildRuntime = persisted.projects.demo?.issueRuntime?.[String(childIds[1])];


### PR DESCRIPTION
## Summary
- harden Fabrica dispatch semantics and trigger-source audit for clearer operational timelines
- persist triage quality criticality/risk profile into issue runtime and use those signals in pipeline acceptance
- add final acceptance summaries, archetype-aware evidence guards, and richer parent rollups

## What changed
### Operational timeline
- adds `dispatchSemantic` / `triggerSource` propagation through dispatch, tick, heartbeat, and bootstrap paths
- enriches audit events for feedback redispatch, session resume, and orphan/session reset behavior
- strengthens timeline-oriented unit/integration/e2e coverage

### Triage to runtime bridge
- persists `qualityCriticality` and `riskProfile` from triage into issue runtime
- preserves those fields across runtime cleanup so later stages can still reason about risk

### Final acceptance hardening
- adds `FinalAcceptanceSummary` to pipeline completion output
- resolves deliverable/archetype more reliably from project stack/environment metadata
- blocks close when evidence is too weak in general or too generic for the archetype
- surfaces short human-readable acceptance summaries in `workerComplete` / `issueComplete`
- enriches parent rollups with high-criticality child visibility and child risk markers

## Validation
- `npm run typecheck`
- `npm run test:unit -- tests/unit/notify.test.ts tests/unit/pipeline-notify.test.ts tests/unit/parent-lifecycle.test.ts tests/unit/close-open-pr.test.ts tests/unit/triage-step.test.ts tests/integration/dispatch-flow.test.ts tests/unit/dispatch-atomicity.test.ts tests/unit/developer-prompt-content.test.ts tests/unit/reviewer-prompt-content.test.ts tests/unit/qa-reviewer-contract.test.ts tests/unit/quality-gates.test.ts tests/unit/done-policies.test.ts tests/unit/stack-policies.test.ts tests/unit/fidelity-brief.test.ts tests/unit/clarification-policy.test.ts tests/unit/triage-logic.test.ts tests/unit/telegram-bootstrap-flow.test.ts`
- `npm run test:e2e -- lib/services/pipeline.e2e.test.ts tests/e2e/orchestration-smoke.e2e.test.ts`

## Notes
- this intentionally keeps the pipeline hardening incremental: stronger acceptance signals and explanations without redesigning the scheduler/runtime wholesale
